### PR TITLE
refactor: init file data

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitFileData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitFileData.java
@@ -47,14 +47,11 @@ public class InitFileData {
         String cvsSplitBy = ",";
 
         try (BufferedReader br = new BufferedReader(new FileReader(csvFilePath))) {
-            // Skip the header line
 
             while ((line = br.readLine()) != null) {
                 String[] data = line.split(cvsSplitBy);
-                // Create and map GonghakCoursesDomain object
                 try {
                     CoursesDomain course = mapToCoursesDomain(data);
-                    // Save to repository
                     coursesDao.save(course);
                 } catch (Exception e) {
                     continue;
@@ -78,16 +75,13 @@ public class InitFileData {
         String cvsSplitBy = ",";
 
         try (BufferedReader br = new BufferedReader(new FileReader(csvFilePath))) {
-            // Skip the header line
             br.readLine();
 
             while ((line = br.readLine()) != null) {
                 String[] data = line.split(cvsSplitBy);
-                // Create and map GonghakCoursesDomain object
                 try {
                     Optional<GonghakCoursesDomain> course = mapToGonghakCoursesDomain(data);
                     if (course.isPresent()) {
-                        // Save to repository only if the Optional contains a value
                         gonghakCorusesDao.save(course.get());
                     }
                 } catch (Exception e) {
@@ -101,10 +95,8 @@ public class InitFileData {
 
     private Optional<GonghakCoursesDomain> mapToGonghakCoursesDomain(String[] data) {
 
-        // 존재하지 않는 course 라면 Optional.empty 반환
         CoursesDomain courseDomain = coursesDao.findByName(data[6].replaceAll("\\s+", ""));
         if (courseDomain == null) {
-            // Return an empty Optional if courseDomain is null
             return Optional.empty();
         }
 
@@ -122,7 +114,6 @@ public class InitFileData {
                 courseCategory = "전공";
                 break;
             default:
-                // 기본적으로는 변경하지 않고 원래 값을 유지
                 break;
         }
 
@@ -135,5 +126,6 @@ public class InitFileData {
             .designCredit(Double.parseDouble(data[8]))
             .build();
 
+        return Optional.of(gonghakCourse);
     }
 }

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/MajorName.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/MajorName.java
@@ -2,7 +2,9 @@ package com.example.gimmegonghakauth.service.recommend;
 
 public enum MajorName {
     ELEC_INFO("전자정보통신공학과"),
-    COMPUTER("컴퓨터공학과");
+    COMPUTER("컴퓨터공학과"),
+    SOFTWARE("소프트웨어학과"),
+    DATA_SCIENCE("데이터사이언스학과");
 
     private final String name;
     MajorName(String name) {


### PR DESCRIPTION
## 🔧연결된 이슈
* closed

## 🛠️작업 내용
* 1. `enum MajorName`  **소프트웨어학과, 데이터사이언스학과** 추가
* 2. `mapToGonghakCoursesDomain` 메서드 리팩토링

## 🤷‍♂️PR이 필요한 이유

### 1. enum MajorName
2학과가 새로 추가됨에 따라 추가하였습니다.

### 2. `mapToGonghakCoursesDomain` 메서드 리팩토링

#### 존재하지 않는 강의
![image](https://github.com/user-attachments/assets/7686b36e-d4f8-4470-9435-121ae02a69e8)
위는 **소프트웨어학과**의 17년도 교과과정표입니다. 하지만 이중 `고급실시간그래픽스` ,`디지털사운드` 등은 **실제 교과가 개설되지 않아** 이를 처리할 로직이 필요했습니다.

```java
CoursesDomain courseDomain = coursesDao.findByName(data[6].replaceAll("\\s+", ""));
if (courseDomain == null) {
    // Return an empty Optional if courseDomain is null
    return Optional.empty();
}
```
```java
Optional<GonghakCoursesDomain> course = mapToGonghakCoursesDomain(data);
if (course.isPresent()) {
    // Save to repository only if the Optional contains a value
    gonghakCorusesDao.save(course.get());
    }
```
원래는 **GongakCoursesDomain**을 return하는 `mapToGonghakCoursesDomain` 메서드를 **Optional<GongakCoursesDomain> 객체를 return** 하도록 리팩토링하여, 해당 객체가 empty면 저장하지 않고, 이후 불필요한 로직도 진행하지 않게 하였습니다.

#### 데이터 포맷팅
아래는 소프트웨어학과의 데이터형식이고,
![image](https://github.com/user-attachments/assets/24383afc-c853-41d3-9d52-ff4ff5609d28)

아래는 전자정보통신공학과의 데이터 형식입니다.
![image](https://github.com/user-attachments/assets/9c202470-9de7-4e5e-aebf-cac3e0ac17ee)

*  **교과구분**

학과별로 **교과구분** 항목이 상이하여 csv 파일들을 살펴보며 가능한 모든 경우의 수를 추스려서 `전문교양`, `BSM`, `전공` ,`MSC` **4가지 항목**으로 통일시켰습니다.

```java
switch (courseCategory) {
    case "중핵필수", "교양필수", "교양선택", "교양선택I", "교양":
        courseCategory = "전문교양";
        break;
    case "전공기초교양", "학문기초교양":
        courseCategory = "BSM";
        break;
    case "전공필수", "전공선택", "전공(설계)", "전공주제", "전공기초":
        courseCategory = "전공";
        break;
    default:
        // 기본적으로는 변경하지 않고 원래 값을 유지
        break;
}
```
* **인증구분**

**인증구분** 데이터도 `인선`, `인필` 형태로 저장되도록 substring을 적용하였습니다.

```java
passCategory(data[5].substring(0, 2))
```

* **교과목명 불일치**

**시간표상**으로는 "대학생을위한진로설계" 처럼 띄어쓰기가 주로 없으며, 공학인증 **홈페이지상**으로는 "대학생을 위한 진로설계" 처럼 띄어쓰기가 적용되어있어 **학과목을 검색하는데 에러가 발생**했습니다. 

시간표상으로는 가끔 띄어쓰기가 존재하는 항목도 있고 불규칙적이라, **모든 교과목에 띄어쓰기를 없애도록 통일하였습니다.**

```java
CoursesDomain courseDomain = coursesDao.findByName(data[6].replaceAll("\\s+", ""));
```



## ✔️PR 체크리스트
* [x] 필요한 테스트를 작성했는가?
* [x] 다른 코드를 깨뜨리지 않았는가?
* [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?