### PR TITLE
fix: calculate

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -214,7 +214,7 @@ public class InitData {
             .year(19).build();
 
         GonghakCoursesDomain gonghakCourses3 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.전선)
+            .courseCategory(CourseCategoryConst.전공)
             .majorsDomain(computerMajor)
             .designCredit(1.0)
             .coursesDomain(testCourse3)
@@ -222,7 +222,7 @@ public class InitData {
             .year(19).build();
 
         GonghakCoursesDomain gonghakCourses4 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.전필)
+            .courseCategory(CourseCategoryConst.전공)
             .majorsDomain(computerMajor)
             .designCredit(1.0)
             .coursesDomain(testCourse5)

--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -171,22 +171,22 @@ public class InitData {
 
         //CompletedCourses
         CompletedCoursesDomain coursesDomain1 = CompletedCoursesDomain.builder()
-            .year(2019)
+            .year(19)
             .semester("1학기")
             .coursesDomain(testCourse1)
             .userDomain(userDomain).build();
         CompletedCoursesDomain coursesDomain2 = CompletedCoursesDomain.builder()
-            .year(2019)
+            .year(19)
             .semester("1학기")
             .coursesDomain(testCourse2)
             .userDomain(userDomain).build();
         CompletedCoursesDomain coursesDomain3 = CompletedCoursesDomain.builder()
-            .year(2019)
+            .year(19)
             .semester("1학기")
             .coursesDomain(testCourse3)
             .userDomain(userDomain).build();
         CompletedCoursesDomain coursesDomain4 = CompletedCoursesDomain.builder()
-            .year(2019)
+            .year(19)
             .semester("1학기")
             .coursesDomain(testCourse4)
             .userDomain(userDomain).build();

--- a/src/main/java/com/example/gimmegonghakauth/constant/CourseCategoryConst.java
+++ b/src/main/java/com/example/gimmegonghakauth/constant/CourseCategoryConst.java
@@ -1,14 +1,10 @@
 package com.example.gimmegonghakauth.constant;
 
 public enum CourseCategoryConst {
-
-    전선("전선"),
-    전필("전필"),
+    
     전문교양("전문교양"),
     교양("교양"),
     MSC("MSC"),
-    전공주제("전공주제"),
-    전공기초("전공기초"),
     전공("전공"),
     BSM("BSM");
 

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakCorusesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakCorusesDao.java
@@ -23,7 +23,7 @@ public interface GonghakCorusesDao extends JpaRepository<GonghakCoursesDomain,Lo
 
     @Query("select new com.example.gimmegonghakauth.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "
         + "left join CompletedCoursesDomain GCCD on GCCD.coursesDomain = GCD.coursesDomain "
-        + "where GCD.majorsDomain = :majorsDomain and GCD.courseCategory = :courseCategory and GCCD.id is null and :studentId is not null")
-    List<IncompletedCoursesDto> findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain);
+        + "where GCD.majorsDomain = :majorsDomain and GCD.year = :year and GCD.courseCategory = :courseCategory and GCCD.id is null and :studentId is not null")
+    List<IncompletedCoursesDto> findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain, @Param("year") Long year);
 
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakCorusesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakCorusesDao.java
@@ -18,7 +18,7 @@ public interface GonghakCorusesDao extends JpaRepository<GonghakCoursesDomain,Lo
 
     @Query("select new com.example.gimmegonghakauth.dto.GonghakCoursesByMajorDto(GCD.coursesDomain.courseId, GCD.coursesDomain.name, GCD.year, GCD.courseCategory, GCD.passCategory, GCD.designCredit, GCD.coursesDomain.credit) from GonghakCoursesDomain GCD "
         + "join CompletedCoursesDomain GCCD on GCD.coursesDomain = GCCD.coursesDomain "
-        + "where GCCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId")
+        + "where GCCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and GCCD.year = GCD.year")
     List<GonghakCoursesByMajorDto> findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId);
 
     @Query("select new com.example.gimmegonghakauth.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GonghakDao implements GonghakRepository{
 
+    private static final int DIVIDER = 1000000;
     private final AbeekDao abeekDao;
     private final GonghakCorusesDao gonghakCorusesDao;
 
@@ -34,7 +35,7 @@ public class GonghakDao implements GonghakRepository{
     // 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
     @Override
     public Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain) {
-        int year = (int) (studentId/1000000);
+        int year = (int) (studentId/DIVIDER);
 //        log.info("year = {}",year);
         return changeToGonghakStandardDto(majorsDomain, year);
     }
@@ -51,7 +52,7 @@ public class GonghakDao implements GonghakRepository{
     public List<IncompletedCoursesDto> findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
         CourseCategoryConst courseCategory, Long studentId, MajorsDomain majorsDomain) {
         return gonghakCorusesDao.findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(
-            courseCategory, studentId, majorsDomain);
+            courseCategory, studentId, majorsDomain, studentId/DIVIDER);
     }
 
     private Optional<GonghakStandardDto> changeToGonghakStandardDto(MajorsDomain majorsDomain, int year) {

--- a/src/main/java/com/example/gimmegonghakauth/domain/CompletedCoursesDomain.java
+++ b/src/main/java/com/example/gimmegonghakauth/domain/CompletedCoursesDomain.java
@@ -38,7 +38,7 @@ public class CompletedCoursesDomain {
     private CoursesDomain coursesDomain;
 
     @NotNull
-    @Range(min = 2015,max = 2024)
+    @Range(min = 17,max = 24)
     @Column(name = "year")
     private int year;
 

--- a/src/main/java/com/example/gimmegonghakauth/service/CompletedCoursesService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/CompletedCoursesService.java
@@ -75,7 +75,7 @@ public class CompletedCoursesService {
             Row row = worksheet.getRow(i);
 
             String yearAsString = dataFormatter.formatCellValue(row.getCell(1));
-            Integer year = Integer.parseInt(yearAsString);  //년도
+            int year = Integer.parseInt(yearAsString)%100;  //년도
 
             String semester = dataFormatter.formatCellValue(row.getCell(2)); //학기
 

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -95,7 +95,7 @@ public class GonghakCalculateService {
         Map<AbeekTypeConst, Double> userAbeekCredit) {
         userCoursesByMajorByGonghakCoursesWithCompletedCourses.forEach(gonghakCoursesByMajorDto -> {
             switch (gonghakCoursesByMajorDto.getCourseCategory()) {
-                case 전선, 전공주제, 전필, 전공:
+                case 전공:
                     stackCredit(AbeekTypeConst.MAJOR, gonghakCoursesByMajorDto, userAbeekCredit);
                     break;
                 case 전문교양:

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
@@ -32,25 +32,16 @@ public class ComputerMajorGonghakRecommendService implements GonghakRecommendSer
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
             userDomain.getStudentId(), userDomain.getMajorsDomain());
 
-        // 수강하지 않은 과목 중 "전공기초" 과목을 반환한다.
-        List<IncompletedCoursesDto> majorBasic = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.전공기초, userDomain.getStudentId(), userDomain.getMajorsDomain()
-        );
-
-        // 수강하지 않은 과목 중 "전공주제" 과목을 반환한다.
-        List<IncompletedCoursesDto> majorSubject = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.전공주제, userDomain.getStudentId(), userDomain.getMajorsDomain()
-        );
-
-        // 수강하지 않은 과목 중 "전문교양" 과목을 반환한다.
+        // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
         List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
             CourseCategoryConst.전문교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
-        // 수강하지 않은 과목 중 "교양" 과목을 반환한다.
-        List<IncompletedCoursesDto> nonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
+        // 수강하지 않은 과목 중 "전공" 과목을 반환한다.
+        List<IncompletedCoursesDto> major = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+            CourseCategoryConst.전공, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
+
         // 수강하지 않은 과목 중 "BSM" 과목을 반환한다.
         List<IncompletedCoursesDto> bsm = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
             CourseCategoryConst.BSM, userDomain.getStudentId(), userDomain.getMajorsDomain()
@@ -67,24 +58,21 @@ public class ComputerMajorGonghakRecommendService implements GonghakRecommendSer
                             abeekRecommend.addAll(bsm);
                             break;
                         case MAJOR:
-                            abeekRecommend.addAll(majorBasic);
-                            abeekRecommend.addAll(majorSubject);
+                            abeekRecommend.addAll(major);
                             break;
                         case DESIGN:
-                            addOnlyDesignCreditOverZero(majorBasic, abeekRecommend);
-                            addOnlyDesignCreditOverZero(majorSubject, abeekRecommend);
+                            addOnlyDesignCreditOverZero(major, abeekRecommend);
                             break;
                         case PROFESSIONAL_NON_MAJOR:
                             abeekRecommend.addAll(professionalNonMajor);
                             break;
                         case NON_MAJOR:
-                            abeekRecommend.addAll(nonMajor);
+                            abeekRecommend.addAll(professionalNonMajor);
                             break;
                         case MINIMUM_CERTI:
                             abeekRecommend.addAll(bsm);
-                            abeekRecommend.addAll(majorBasic);
-                            abeekRecommend.addAll(majorSubject);
-                            abeekRecommend.addAll(nonMajor);
+                            abeekRecommend.addAll(professionalNonMajor);
+                            abeekRecommend.addAll(major);
                             break;
                     }
                     coursesByAbeekTypeWithoutCompleteCourses.put(abeekType, abeekRecommend);

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
@@ -31,14 +31,9 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
             userDomain.getStudentId(), userDomain.getMajorsDomain());
 
-        // 수강하지 않은 과목 중 "전선" 과목을 반환한다.
-        List<IncompletedCoursesDto> majorSelective = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.전선, userDomain.getStudentId(), userDomain.getMajorsDomain()
-        );
-
-        // 수강하지 않은 과목 중 "전필" 과목을 반환한다.
-        List<IncompletedCoursesDto> majorRequired = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.전필, userDomain.getStudentId(), userDomain.getMajorsDomain()
+        // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
+        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+            CourseCategoryConst.전문교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
         // 수강하지 않은 과목 중 "전공" 과목을 반환한다.
@@ -46,17 +41,7 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
             CourseCategoryConst.전공, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
-        // 수강하지 않은 과목 중 "전문교양" 과목을 반환한다.
-        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.전문교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
-        );
-
-        // 수강하지 않은 과목 중 "교양" 과목을 반환한다.
-        List<IncompletedCoursesDto> nonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-            CourseCategoryConst.교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
-        );
-
-        // // 수강하지 않은 과목 중 "MSC" 과목을 반환한다.
+        // 수강하지 않은 과목 중 "MSC" 과목을 반환한다.
         List<IncompletedCoursesDto> msc = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
             CourseCategoryConst.MSC, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
@@ -73,25 +58,20 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
                             break;
                         case MAJOR:
                             abeekRecommend.addAll(major);
-                            abeekRecommend.addAll(majorRequired);
-                            abeekRecommend.addAll(majorSelective);
                             break;
                         case DESIGN:
                             addOnlyDesignCreditOverZero(major, abeekRecommend);
-                            addOnlyDesignCreditOverZero(majorRequired, abeekRecommend);
-                            addOnlyDesignCreditOverZero(majorSelective, abeekRecommend);
                             break;
                         case PROFESSIONAL_NON_MAJOR:
                             abeekRecommend.addAll(professionalNonMajor);
                             break;
                         case NON_MAJOR:
-                            abeekRecommend.addAll(nonMajor);
+                            abeekRecommend.addAll(professionalNonMajor);
                             break;
                         case MINIMUM_CERTI:
                             abeekRecommend.addAll(msc);
-                            abeekRecommend.addAll(majorRequired);
-                            abeekRecommend.addAll(majorSelective);
-                            abeekRecommend.addAll(nonMajor);
+                            abeekRecommend.addAll(major);
+                            abeekRecommend.addAll(professionalNonMajor);
                             break;
                     }
                     coursesByAbeekTypeWithoutCompleteCourses.put(abeekType, abeekRecommend);

--- a/src/test/java/com/example/gimmegonghakauth/Service/CompletedCoursesServiceDataTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/Service/CompletedCoursesServiceDataTest.java
@@ -87,7 +87,7 @@ public class CompletedCoursesServiceDataTest {
             CompletedCoursesDomain.builder().
                 userDomain(userDao.findByStudentId(19011684L).get()).
                 coursesDomain(coursesDao.findByCourseId(12345L)).
-                year(2023).semester("1학기").
+                year(23).semester("1학기").
                 build();
 
         //기이수 과목 데이터2
@@ -95,7 +95,7 @@ public class CompletedCoursesServiceDataTest {
             CompletedCoursesDomain.builder().
                 userDomain(userDao.findByStudentId(19011684L).get()).
                 coursesDomain(coursesDao.findByCourseId(54321L)).
-                year(2023).semester("1학기").
+                year(23).semester("1학기").
                 build();
 
         //기이수 과목 저장
@@ -134,7 +134,7 @@ public class CompletedCoursesServiceDataTest {
             CompletedCoursesDomain.builder().
                 userDomain(userDao.findByStudentId(19011684L).get()).
                 coursesDomain(coursesDao.findByCourseId(12345L)).
-                year(2023).semester("1학기").
+                year(23).semester("1학기").
                 build();
 
         completedCoursesDao.save(data1);
@@ -162,14 +162,14 @@ public class CompletedCoursesServiceDataTest {
             CompletedCoursesDomain.builder().
                 userDomain(userDao.findByStudentId(19011684L).get()).
                 coursesDomain(coursesDao.findByCourseId(12345L)).
-                year(2023).semester("1학기").
+                year(23).semester("1학기").
                 build();
         //기이수 과목 데이터 2
         CompletedCoursesDomain data2 =
             CompletedCoursesDomain.builder().
                 userDomain(userDao.findByStudentId(19011684L).get()).
                 coursesDomain(coursesDao.findByCourseId(12345L)).
-                year(2023).semester("1학기").
+                year(23).semester("1학기").
                 build();
 
         completedCoursesDao.save(data1);

--- a/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.ActiveProfiles;
 @SpringBootTest
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @ActiveProfiles("test")
-//출처: https://0soo.tistory.com/194?category=576925
 class GonghakRepositoryTest {
 
     private static final Long COM_TEST_STUDENT_ID = 19011706L;
@@ -41,6 +40,7 @@ class GonghakRepositoryTest {
     private MajorsDomain COM_TEST_MAJORDOMAIN;
 
     private MajorsDomain WRONG_TEST_MAJORDOMAIN;
+
 
     @BeforeAll
     void setInit(){
@@ -55,7 +55,7 @@ class GonghakRepositoryTest {
     @DisplayName("dao 메서드 상태 출력")
     void displayDaoMethod(){
         List<IncompletedCoursesDto> withoutCompleteCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-                CourseCategoryConst.전선, COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN
+                CourseCategoryConst.전공, COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN
         );
 
         withoutCompleteCourses.forEach(
@@ -113,7 +113,7 @@ class GonghakRepositoryTest {
 
         assertThat(passCategories).containsAll(List.of("인필","인선"));
 
-        assertThat(courseCategories).containsAnyElementsOf(List.of(CourseCategoryConst.전문교양,CourseCategoryConst.전공주제,CourseCategoryConst.BSM));
+        assertThat(courseCategories).containsAnyElementsOf(List.of(CourseCategoryConst.전문교양,CourseCategoryConst.전공,CourseCategoryConst.BSM));
     }
 
     @Test
@@ -123,14 +123,14 @@ class GonghakRepositoryTest {
         Arrays.stream(CourseCategoryConst.values()).forEach(
                 courseCategory -> {
                     List<IncompletedCoursesDto> testCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
-                            CourseCategoryConst.전필,
+                            CourseCategoryConst.전공,
                             COM_TEST_STUDENT_ID,
                             COM_TEST_MAJORDOMAIN
                     );
 
                     testCourses.forEach(
                             incompletedCoursesDto -> {
-                                assertThat(incompletedCoursesDto.getCourseCategory()).isEqualTo(CourseCategoryConst.전필);
+                                assertThat(incompletedCoursesDto.getCourseCategory()).isEqualTo(CourseCategoryConst.전공);
                             }
                     );
                 }


### PR DESCRIPTION
## 🔧연결된 이슈
* closed
## 🛠️작업 내용
* **결과, 추천**에 필요한 쿼리문 수정
* `CourseCategoryConst` 리팩토링

## 🤷‍♂️PR이 필요한 이유
### 1.  **결과, 추천**에 필요한 쿼리문 수정
**기존 쿼리문이 데이터를 중복해서 읽어들이는 오류가 발생**하여 이를 수정하였습니다.
#### result
* **기존의 쿼리문:** **이수한 '학수번호'와 사용자의 '학과'가 같은** `GonghakCourse`의 과목들을 모두 불러옴
* **바뀐 쿼리문:** **이수한 '학수번호', 사용자의 '학과', 수강한 '년도'가 모두 같은** `GonghakCourse`의 과목을 불러옴

#### recommend
* **기존의 쿼리문:** `GonghakCourse`의 과목중 **사용자가 이수하지 않은 과목 모두 불러옴**
* **바뀐 쿼리문:** GonghakCourse의 과목중 **사용자의 '학번'과 일치하는 '년도'를 가지는 과목을 모두 불러옴**


### 2. `CourseCategoryConst` 리팩토링
기존 'CourseCategoryConst' 는 **'전선'**, **'전필'**, **'교양'**, **'MSC'**, **'전공주제'**, **'전공기초'**, **'전공'**, '**BSM'** 으로 나누어졌음

하지만 현재 서비스는  **전공선택 ,필수를 따로 계산하지 않으며** 오직 **'전문교양'**, **'교양'**,  **'MSC'**, **'BSM'**, **'전공'** 으로 나누어 로직이 진행되므로 **로직에 필요하지 않은 나머지 항목들은 상위 항목으로 통일시킴**

![image](https://github.com/user-attachments/assets/73c59030-5dd9-4b11-a5e8-ce0ddbb507f6)


## ✔️PR 체크리스트
* [x] 필요한 테스트를 작성했는가?
* [x] 다른 코드를 깨뜨리지 않았는가?
* [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?