### PR TITLE
refactor: GonghakRepository 리팩토링

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -5,7 +5,7 @@ import com.example.gimmegonghakauth.constant.CourseCategoryConst;
 import com.example.gimmegonghakauth.dao.AbeekDao;
 import com.example.gimmegonghakauth.dao.CompletedCoursesDao;
 import com.example.gimmegonghakauth.dao.CoursesDao;
-import com.example.gimmegonghakauth.dao.GonghakCorusesDao;
+import com.example.gimmegonghakauth.dao.GonghakCoursesDao;
 import com.example.gimmegonghakauth.dao.MajorsDao;
 import com.example.gimmegonghakauth.dao.UserDao;
 import com.example.gimmegonghakauth.domain.AbeekDomain;
@@ -33,7 +33,7 @@ public class InitData {
     private final AbeekDao abeekDao;
     private final CompletedCoursesDao completedCoursesDao;
     private final CoursesDao coursesDao;
-    private final GonghakCorusesDao gonghakCorusesDao;
+    private final GonghakCoursesDao gonghakCoursesDao;
     private final UserDao userDao;
     private final PasswordEncoder passwordEncoder;
 
@@ -229,10 +229,10 @@ public class InitData {
             .passCategory("인선")
             .year(19).build();
 
-        gonghakCorusesDao.save(gonghakCourses1);
-        gonghakCorusesDao.save(gonghakCourses2);
-        gonghakCorusesDao.save(gonghakCourses3);
-        gonghakCorusesDao.save(gonghakCourses4);
+        gonghakCoursesDao.save(gonghakCourses1);
+        gonghakCoursesDao.save(gonghakCourses2);
+        gonghakCoursesDao.save(gonghakCourses3);
+        gonghakCoursesDao.save(gonghakCourses4);
     }
 
 

--- a/src/main/java/com/example/gimmegonghakauth/InitFileData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitFileData.java
@@ -2,7 +2,7 @@ package com.example.gimmegonghakauth;
 
 import com.example.gimmegonghakauth.constant.CourseCategoryConst;
 import com.example.gimmegonghakauth.dao.CoursesDao;
-import com.example.gimmegonghakauth.dao.GonghakCorusesDao;
+import com.example.gimmegonghakauth.dao.GonghakCoursesDao;
 import com.example.gimmegonghakauth.dao.MajorsDao;
 import com.example.gimmegonghakauth.domain.CoursesDomain;
 import com.example.gimmegonghakauth.domain.GonghakCoursesDomain;
@@ -24,7 +24,7 @@ public class InitFileData {
 
     private final MajorsDao majorsDao;
     private final CoursesDao coursesDao;
-    private final GonghakCorusesDao gonghakCorusesDao;
+    private final GonghakCoursesDao gonghakCoursesDao;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -82,7 +82,7 @@ public class InitFileData {
                 try {
                     Optional<GonghakCoursesDomain> course = mapToGonghakCoursesDomain(data);
                     if (course.isPresent()) {
-                        gonghakCorusesDao.save(course.get());
+                        gonghakCoursesDao.save(course.get());
                     }
                 } catch (Exception e) {
                     continue;

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
@@ -17,11 +17,11 @@ public interface GonghakCoursesDao extends JpaRepository<GonghakCoursesDomain,Lo
     @Query("select new com.example.gimmegonghakauth.dto.GonghakCoursesByMajorDto(GCD.coursesDomain.courseId, GCD.coursesDomain.name, GCD.year, GCD.courseCategory, GCD.passCategory, GCD.designCredit, GCD.coursesDomain.credit) from GonghakCoursesDomain GCD "
         + "join CompletedCoursesDomain CCD on GCD.coursesDomain = CCD.coursesDomain "
         + "where CCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and CCD.year = GCD.year")
-    List<GonghakCoursesByMajorDto> findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId);
+    List<GonghakCoursesByMajorDto> findUserCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId);
 
     @Query("select new com.example.gimmegonghakauth.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "
         + "left join CompletedCoursesDomain CCD on CCD.coursesDomain = GCD.coursesDomain "
         + "where GCD.majorsDomain = :majorsDomain and GCD.year = :year and GCD.courseCategory = :courseCategory and CCD.id is null and :studentId is not null")
-    List<IncompletedCoursesDto> findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain, @Param("year") Long year);
+    List<IncompletedCoursesDto> findUserIncompletedCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain, @Param("year") Long year);
 
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
@@ -12,18 +12,16 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface GonghakCorusesDao extends JpaRepository<GonghakCoursesDomain,Long> {
-
-    List<GonghakCoursesDomain> findAllByMajorsDomain(MajorsDomain majorsDomain);
+public interface GonghakCoursesDao extends JpaRepository<GonghakCoursesDomain,Long> {
 
     @Query("select new com.example.gimmegonghakauth.dto.GonghakCoursesByMajorDto(GCD.coursesDomain.courseId, GCD.coursesDomain.name, GCD.year, GCD.courseCategory, GCD.passCategory, GCD.designCredit, GCD.coursesDomain.credit) from GonghakCoursesDomain GCD "
-        + "join CompletedCoursesDomain GCCD on GCD.coursesDomain = GCCD.coursesDomain "
-        + "where GCCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and GCCD.year = GCD.year")
+        + "join CompletedCoursesDomain CCD on GCD.coursesDomain = CCD.coursesDomain "
+        + "where CCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and CCD.year = GCD.year")
     List<GonghakCoursesByMajorDto> findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId);
 
     @Query("select new com.example.gimmegonghakauth.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "
-        + "left join CompletedCoursesDomain GCCD on GCCD.coursesDomain = GCD.coursesDomain "
-        + "where GCD.majorsDomain = :majorsDomain and GCD.year = :year and GCD.courseCategory = :courseCategory and GCCD.id is null and :studentId is not null")
+        + "left join CompletedCoursesDomain CCD on CCD.coursesDomain = GCD.coursesDomain "
+        + "where GCD.majorsDomain = :majorsDomain and GCD.year = :year and GCD.courseCategory = :courseCategory and CCD.id is null and :studentId is not null")
     List<IncompletedCoursesDto> findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(@Param("courseCategory") CourseCategoryConst courseCategory, @Param("studentId") Long studentId, @Param("majorsDomain") MajorsDomain majorsDomain, @Param("year") Long year);
 
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -42,17 +42,16 @@ public class GonghakDao implements GonghakRepository{
 
     // gonghakCourse 중 이수한 과목을 불러온다.
     @Override
-    public List<GonghakCoursesByMajorDto> findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(
+    public List<GonghakCoursesByMajorDto> findUserCompletedCourses(
         Long studentId, MajorsDomain majorsDomain) {
-        return gonghakCoursesDao.findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(studentId,majorsDomain.getId());
+        return gonghakCoursesDao.findUserCompletedCourses(studentId,majorsDomain.getId());
     }
 
-    //
+    // gonghakCourse 중 이수하지 않은 과목을 불러온다.
     @Override
-    public List<IncompletedCoursesDto> findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+    public List<IncompletedCoursesDto> findUserIncompletedCourses(
         CourseCategoryConst courseCategory, Long studentId, MajorsDomain majorsDomain) {
-        return gonghakCoursesDao.findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(
-            courseCategory, studentId, majorsDomain, studentId/DIVIDER);
+        return gonghakCoursesDao.findUserIncompletedCourses(courseCategory, studentId, majorsDomain, studentId/DIVIDER);
     }
 
     private Optional<GonghakStandardDto> changeToGonghakStandardDto(MajorsDomain majorsDomain, int year) {

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -24,7 +24,7 @@ public class GonghakDao implements GonghakRepository{
 
     private static final int DIVIDER = 1000000;
     private final AbeekDao abeekDao;
-    private final GonghakCorusesDao gonghakCorusesDao;
+    private final GonghakCoursesDao gonghakCoursesDao;
 
     @Override
     public AbeekDomain save(AbeekDomain abeekDomain) {
@@ -44,14 +44,14 @@ public class GonghakDao implements GonghakRepository{
     @Override
     public List<GonghakCoursesByMajorDto> findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(
         Long studentId, MajorsDomain majorsDomain) {
-        return gonghakCorusesDao.findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(studentId,majorsDomain.getId());
+        return gonghakCoursesDao.findUserCoursesByMajorAndGonghakCoursesWithCompletedCourses(studentId,majorsDomain.getId());
     }
 
     //
     @Override
     public List<IncompletedCoursesDto> findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
         CourseCategoryConst courseCategory, Long studentId, MajorsDomain majorsDomain) {
-        return gonghakCorusesDao.findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(
+        return gonghakCoursesDao.findUserCoursesByMajorAndCourseCategoryAndGonghakCoursesWithoutCompleteCourses(
             courseCategory, studentId, majorsDomain, studentId/DIVIDER);
     }
 

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
@@ -17,9 +17,9 @@ public interface GonghakRepository {
 
     Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain);
 
-    List<GonghakCoursesByMajorDto> findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(Long studentId, MajorsDomain majorsDomain);
+    List<GonghakCoursesByMajorDto> findUserCompletedCourses(Long studentId, MajorsDomain majorsDomain);
 
-    List<IncompletedCoursesDto> findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+    List<IncompletedCoursesDto> findUserIncompletedCourses(
         CourseCategoryConst courseCategory,Long studentId, MajorsDomain majorsDomain);
 
 }

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -35,7 +35,7 @@ public class GonghakCalculateService {
 
         // user 공학 상태 테이블
         // gonghakCourse 중 이수한 과목을 불러온다.
-        List<GonghakCoursesByMajorDto> userCoursesByMajorByGonghakCoursesWithCompletedCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(
+        List<GonghakCoursesByMajorDto> userCoursesByMajorByGonghakCoursesWithCompletedCourses = gonghakRepository.findUserCompletedCourses(
             userDomain.getStudentId(), userDomain.getMajorsDomain());
 
         // user

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
@@ -33,17 +33,17 @@ public class ComputerMajorGonghakRecommendService implements GonghakRecommendSer
             userDomain.getStudentId(), userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
-        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.전문교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
         // 수강하지 않은 과목 중 "전공" 과목을 반환한다.
-        List<IncompletedCoursesDto> major = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> major = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.전공, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
         // 수강하지 않은 과목 중 "BSM" 과목을 반환한다.
-        List<IncompletedCoursesDto> bsm = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> bsm = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.BSM, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
@@ -32,17 +32,17 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
             userDomain.getStudentId(), userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
-        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.전문교양, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
         // 수강하지 않은 과목 중 "전공" 과목을 반환한다.
-        List<IncompletedCoursesDto> major = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> major = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.전공, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 
         // 수강하지 않은 과목 중 "MSC" 과목을 반환한다.
-        List<IncompletedCoursesDto> msc = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> msc = gonghakRepository.findUserIncompletedCourses(
             CourseCategoryConst.MSC, userDomain.getStudentId(), userDomain.getMajorsDomain()
         );
 

--- a/src/test/java/com/example/gimmegonghakauth/Service/GonghakCalculateServiceTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/Service/GonghakCalculateServiceTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.example.gimmegonghakauth.Service.GonghakCalculateServiceTest.CalculateTestConfig;
 import com.example.gimmegonghakauth.constant.AbeekTypeConst;
 import com.example.gimmegonghakauth.dao.AbeekDao;
-import com.example.gimmegonghakauth.dao.GonghakCorusesDao;
+import com.example.gimmegonghakauth.dao.GonghakCoursesDao;
 import com.example.gimmegonghakauth.dao.GonghakDao;
 import com.example.gimmegonghakauth.dao.GonghakRepository;
 import com.example.gimmegonghakauth.domain.MajorsDomain;
@@ -51,11 +51,11 @@ class GonghakCalculateServiceTest {
     @RequiredArgsConstructor
     static class CalculateTestConfig{
         private final AbeekDao abeekDao;
-        private final GonghakCorusesDao gonghakCorusesDao;
+        private final GonghakCoursesDao gonghakCoursesDao;
 
         @Bean
         public GonghakRepository gonghakRepository(){
-            return new GonghakDao(abeekDao,gonghakCorusesDao);
+            return new GonghakDao(abeekDao, gonghakCoursesDao);
         }
 
         @Bean

--- a/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
@@ -54,7 +54,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("dao 메서드 상태 출력")
     void displayDaoMethod(){
-        List<IncompletedCoursesDto> withoutCompleteCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+        List<IncompletedCoursesDto> withoutCompleteCourses = gonghakRepository.findUserIncompletedCourses(
                 CourseCategoryConst.전공, COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN
         );
 
@@ -64,7 +64,7 @@ class GonghakRepositoryTest {
                 }
         );
 
-        List<GonghakCoursesByMajorDto> withCompletedCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(
+        List<GonghakCoursesByMajorDto> withCompletedCourses = gonghakRepository.findUserCompletedCourses(
                 COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN
         );
 
@@ -89,7 +89,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("findUserCoursesByMajorByGonghakCoursesWithCompletedCourses 테스트 ")
     void findUserCoursesByMajorByGonghakCoursesWithCompletedCoursesTest() {
-        List<GonghakCoursesByMajorDto> userDataForCalculate = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithCompletedCourses(
+        List<GonghakCoursesByMajorDto> userDataForCalculate = gonghakRepository.findUserCompletedCourses(
                 COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN);
 
         log.info("userDataForCalculate size = {}",userDataForCalculate.size());
@@ -122,7 +122,7 @@ class GonghakRepositoryTest {
 
         Arrays.stream(CourseCategoryConst.values()).forEach(
                 courseCategory -> {
-                    List<IncompletedCoursesDto> testCourses = gonghakRepository.findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses(
+                    List<IncompletedCoursesDto> testCourses = gonghakRepository.findUserIncompletedCourses(
                             CourseCategoryConst.전공,
                             COM_TEST_STUDENT_ID,
                             COM_TEST_MAJORDOMAIN

--- a/src/test/java/com/example/gimmegonghakauth/domain/DomainTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/domain/DomainTest.java
@@ -5,7 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.example.gimmegonghakauth.constant.AbeekTypeConst;
 import com.example.gimmegonghakauth.dao.AbeekDao;
-import com.example.gimmegonghakauth.dao.GonghakCorusesDao;
+import com.example.gimmegonghakauth.dao.GonghakCoursesDao;
 import com.example.gimmegonghakauth.dao.GonghakDao;
 import com.example.gimmegonghakauth.dao.GonghakRepository;
 import com.example.gimmegonghakauth.dao.MajorsDao;
@@ -39,11 +39,11 @@ public class DomainTest {
     @RequiredArgsConstructor
     public static class DomainTestConfig {
         private final AbeekDao abeekDao;
-        private final GonghakCorusesDao gonghakCorusesDao;
+        private final GonghakCoursesDao gonghakCoursesDao;
 
         @Bean
         public GonghakRepository gonghakRepository(){
-            return new GonghakDao(abeekDao,gonghakCorusesDao);
+            return new GonghakDao(abeekDao, gonghakCoursesDao);
         }
     }
 


### PR DESCRIPTION
## 🔧연결된 이슈
- closed

## 🛠️작업 내용
- `GonghakRepository`의 메서드 이름 간소화
- `GonghakCoursesDao` JPQL 메서드 이름 간소화 및 `CompletedCourseDomain` 별칭 수정(`GCCD` -> `CCD`)
- `GonghakCoursesDao` 클래스 이름 오타 수정
- `GonghakCoursesDao`에서 사용하지 않는 메서드 삭제

## 🤷‍♂️PR이 필요한 이유
`GonghakCoursesDao`의 메서드는 현재 JPQL을 사용한 쿼리 메서드를 갖고 있습니다.
해당 JPQL을 통해 쿼리 메서드가 어떠한 조건으로 데이터를 불러오고 있는지 충분히 보여주고 있다고 생각했습니다.

결국, 사용자가 이수하거나 이수하지 않은 공학인증 과목을 가져오는 메서드이기에 좀 더 직관적인 이름을 부여함과 동시에
메서드의 길이를 줄이는게 코드를 읽는데에도 더 편리할 것 같아서 메서드 이름을 다음과 같이 수정하였습니다.

- `findUserCoursesByMajorByGonghakCoursesWithCompletedCourses` -> `findUserCompletedCourses`
- `findUserCoursesByMajorByGonghakCoursesWithoutCompleteCourses` -> `findUserInCompletedCourses`



## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
