### PR TITLE
refactor: GonghakDao

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -49,37 +49,37 @@ public class InitData {
         majorsDao.save(computerMajor);
         majorsDao.save(elecInfoMajor);
 
-        //19학년도 computerMajor
+        //24학년도 computerMajor
         AbeekDomainBuilder abeek1 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.BSM)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(18);
         AbeekDomainBuilder abeek2 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(14);
         AbeekDomainBuilder abeek3 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.DESIGN)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(12);
+            .year(24)
+            .minCredit(10);
         AbeekDomainBuilder abeek4 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MAJOR)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(60);
+            .year(24)
+            .minCredit(45);
         AbeekDomainBuilder abeek5 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MINIMUM_CERTI)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(92);
+            .year(24)
+            .minCredit(77);
 
         abeekDao.save(abeek1.build());
         abeekDao.save(abeek2.build());
@@ -87,37 +87,37 @@ public class InitData {
         abeekDao.save(abeek4.build());
         abeekDao.save(abeek5.build());
 
-        //19학년도 전정통
+        //24학년도 전정통
         AbeekDomainBuilder abeek21 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MSC)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(30);
+            .year(24)
+            .minCredit(27);
         AbeekDomainBuilder abeek22 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(14);
         AbeekDomainBuilder abeek23 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.DESIGN)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(9);
         AbeekDomainBuilder abeek24 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MAJOR)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(54);
+            .year(24)
+            .minCredit(45);
         AbeekDomainBuilder abeek25 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MINIMUM_CERTI)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(98);
+            .year(24)
+            .minCredit(86);
 
         abeekDao.save(abeek21.build());
         abeekDao.save(abeek22.build());

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GonghakDao implements GonghakRepository{
 
     private static final int DIVIDER = 1000000;
-    private static final int YEAR = 24;
+    private static final int LATEST_YEAR = 24;
     private final AbeekDao abeekDao;
     private final GonghakCoursesDao gonghakCoursesDao;
 
@@ -36,7 +36,7 @@ public class GonghakDao implements GonghakRepository{
     // 최신년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
     @Override
     public Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain){
-        return changeToGonghakStandardDto(majorsDomain, YEAR);
+        return changeToGonghakStandardDto(majorsDomain, LATEST_YEAR);
     }
 
     // gonghakCourse 중 이수한 과목을 불러온다.

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GonghakDao implements GonghakRepository{
 
     private static final int DIVIDER = 1000000;
+    private static final int YEAR = 24;
     private final AbeekDao abeekDao;
     private final GonghakCoursesDao gonghakCoursesDao;
 
@@ -32,12 +33,10 @@ public class GonghakDao implements GonghakRepository{
         return abeekDomain;
     }
 
-    // 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+    // 최신년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
     @Override
-    public Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain) {
-        int year = (int) (studentId/DIVIDER);
-//        log.info("year = {}",year);
-        return changeToGonghakStandardDto(majorsDomain, year);
+    public Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain){
+        return changeToGonghakStandardDto(majorsDomain, YEAR);
     }
 
     // gonghakCourse 중 이수한 과목을 불러온다.
@@ -59,8 +58,6 @@ public class GonghakDao implements GonghakRepository{
         Map<AbeekTypeConst, Integer> standards = new ConcurrentHashMap<>();
         // year, major를 기준으로 abeek 데이터를 불러온다.
         List<AbeekDomain> allByYearAndMajorsDomain = abeekDao.findAllByYearAndMajorsDomain(year, majorsDomain);
-
-        log.info("allByYearAndMajorsDomain.isEmpty() = {}", allByYearAndMajorsDomain.isEmpty());
 
         // abeek을 기반으로 abeekType(영역별 구분),minCredit(영역별 인증학점) 저장한다.
         allByYearAndMajorsDomain.forEach(

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
@@ -15,7 +15,7 @@ public interface GonghakRepository {
 
     AbeekDomain save(AbeekDomain abeekDomain);
 
-    Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain);
+    Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain);
 
     List<GonghakCoursesByMajorDto> findUserCompletedCourses(Long studentId, MajorsDomain majorsDomain);
 

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -25,7 +25,7 @@ public class GonghakCalculateService {
     @Transactional(readOnly = true)
     public Optional<GonghakResultDto> getResultRatio(UserDomain userDomain) {
 
-        // findLatestStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+        // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
             userDomain.getMajorsDomain());
 

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -25,9 +25,9 @@ public class GonghakCalculateService {
     @Transactional(readOnly = true)
     public Optional<GonghakResultDto> getResultRatio(UserDomain userDomain) {
 
-        // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+        // findLatestStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+            userDomain.getMajorsDomain());
 
         // default user abeek 학점 상태 map
         Map<AbeekTypeConst, Double> userAbeekCredit = getUserAbeekCreditDefault(

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
@@ -29,8 +29,7 @@ public class ComputerMajorGonghakRecommendService implements GonghakRecommendSer
         GonghakRecommendCoursesDto gonghakRecommendCoursesDto = new GonghakRecommendCoursesDto();
 
         // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
         List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
@@ -28,8 +28,7 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
         GonghakRecommendCoursesDto gonghakRecommendCoursesDto = new GonghakRecommendCoursesDto();
 
         // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
         List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(

--- a/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
@@ -78,7 +78,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("GonghakStandardDto 5가지 상태 모두 포함되어있는지 확인")
     void findStandardKeySetTest() {
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN);
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(COM_TEST_MAJORDOMAIN);
         log.info("testStandard status ={}", standard.get().getStandards());
         Map<AbeekTypeConst, Integer> testStandard = standard.get().getStandards();
         assertThat(testStandard.keySet()).contains(AbeekTypeConst.BSM,AbeekTypeConst.PROFESSIONAL_NON_MAJOR,AbeekTypeConst.DESIGN,AbeekTypeConst.MAJOR,AbeekTypeConst.MINIMUM_CERTI);
@@ -140,9 +140,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("findStandard가 없을 때 - Wrong Major")
     void findStandardWrongMajorDomainTest(){
-        Optional<GonghakStandardDto> wrongStandard = gonghakRepository.findStandard(
-                COM_TEST_STUDENT_ID,
-                WRONG_TEST_MAJORDOMAIN);
+        Optional<GonghakStandardDto> wrongStandard = gonghakRepository.findStandard(WRONG_TEST_MAJORDOMAIN);
         assertThat(wrongStandard.get().getStandards().isEmpty()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## 🔧연결된 이슈
- https://github.com/Sejong-Java-Study/gonghak98/issues/57

## 🛠️작업 내용
- **GonghakDao**의 `findStandard` 메서드를 **최신년도에 해당하는 학과 기준**을 불러오도록 변경하고 연관된 사항들을 변경사항에 맞게 변경하였습니다.

## 🤷‍♂️PR이 필요한 이유
- 기존의 **'사용자의 입학년도'** 를 기준으로 인증 기준을 가져오는 잘못된 방식에서 **'최신년도'** 기준으로 인증 기준을 가져오는 방식으로 변경하였습니다.
- **'기준 학점'** 외 **'세부 사항'** 들은 **사용자의 입학년도**를 기준삼는것이 맞아서 기존의 추천로직은 따로 수정하지 않았습니다.

## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
