### PR TITLE
Refactor gonghak courses dao

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -17,6 +17,7 @@ import com.example.gimmegonghakauth.domain.MajorsDomain;
 import com.example.gimmegonghakauth.domain.UserDomain;
 import com.example.gimmegonghakauth.service.recommend.MajorName;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
@@ -31,11 +32,17 @@ public class InitData {
 
     private final MajorsDao majorsDao;
     private final AbeekDao abeekDao;
-    private final CompletedCoursesDao completedCoursesDao;
-    private final CoursesDao coursesDao;
-    private final GonghakCoursesDao gonghakCoursesDao;
     private final UserDao userDao;
     private final PasswordEncoder passwordEncoder;
+
+    @Value("${admin1}")
+    private Long admin1;
+
+    @Value("${admin2}")
+    private Long admin2;
+
+    @Value("${admin3}")
+    private Long admin3;
 
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
@@ -46,8 +53,16 @@ public class InitData {
         MajorsDomain elecInfoMajor = MajorsDomain.builder()
             .id(2L)
             .major(MajorName.ELEC_INFO.getName()).build();
+        MajorsDomain softwareMajor = MajorsDomain.builder()
+            .id(3L)
+            .major(MajorName.SOFTWARE.getName()).build();
+        MajorsDomain dataScienceMajor = MajorsDomain.builder()
+            .id(4L)
+            .major(MajorName.DATA_SCIENCE.getName()).build();
         majorsDao.save(computerMajor);
         majorsDao.save(elecInfoMajor);
+        majorsDao.save(softwareMajor);
+        majorsDao.save(dataScienceMajor);
 
         //24학년도 computerMajor
         AbeekDomainBuilder abeek1 = AbeekDomain.builder()
@@ -125,114 +140,107 @@ public class InitData {
         abeekDao.save(abeek24.build());
         abeekDao.save(abeek25.build());
 
+        //24학년도 소프트웨어
+        AbeekDomainBuilder abeek31 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.BSM)
+            .majorsDomain(softwareMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(18);
+        AbeekDomainBuilder abeek32 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
+            .majorsDomain(softwareMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(14);
+        AbeekDomainBuilder abeek33 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.DESIGN)
+            .majorsDomain(softwareMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(12);
+        AbeekDomainBuilder abeek34 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.MAJOR)
+            .majorsDomain(softwareMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(45);
+        AbeekDomainBuilder abeek35 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.MINIMUM_CERTI)
+            .majorsDomain(softwareMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(77);
+
+        abeekDao.save(abeek31.build());
+        abeekDao.save(abeek32.build());
+        abeekDao.save(abeek33.build());
+        abeekDao.save(abeek34.build());
+        abeekDao.save(abeek35.build());
+
+        //24학년도 데이터사이언스
+        AbeekDomainBuilder abeek41 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.BSM)
+            .majorsDomain(dataScienceMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(15);
+        AbeekDomainBuilder abeek42 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
+            .majorsDomain(dataScienceMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(14);
+        AbeekDomainBuilder abeek43 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.DESIGN)
+            .majorsDomain(dataScienceMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(9);
+        AbeekDomainBuilder abeek44 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.MAJOR)
+            .majorsDomain(dataScienceMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(45);
+        AbeekDomainBuilder abeek45 = AbeekDomain.builder()
+            .abeekType(AbeekTypeConst.MINIMUM_CERTI)
+            .majorsDomain(dataScienceMajor)
+            .note("this is a test note")
+            .year(24)
+            .minCredit(74);
+
+        abeekDao.save(abeek41.build());
+        abeekDao.save(abeek42.build());
+        abeekDao.save(abeek43.build());
+        abeekDao.save(abeek44.build());
+        abeekDao.save(abeek45.build());
+
         //User
-        UserDomain userDomain = UserDomain.builder()
-            .email("testEmail@sju.ac.kr")
+        UserDomain user1 = UserDomain.builder()
+            .email("testEmail1@sju.ac.kr")
+            .name("조태현")
+            .password(passwordEncoder.encode("qwer"))
+            .studentId(admin1)
+            .majorsDomain(elecInfoMajor).build();
+        userDao.save(user1);
+
+        UserDomain user2 = UserDomain.builder()
+            .email("testEmail2@sju.ac.kr")
+            .name("이희수")
+            .password(passwordEncoder.encode("qwer"))
+            .studentId(admin2)
+            .majorsDomain(dataScienceMajor).build();
+        userDao.save(user2);
+
+        UserDomain user3 = UserDomain.builder()
+            .email("testEmail3@sju.ac.kr")
             .name("홍지섭")
             .password(passwordEncoder.encode("qwer"))
-            .studentId(19011706L)
+            .studentId(admin3)
             .majorsDomain(computerMajor).build();
-        userDao.save(userDomain);
+        userDao.save(user3);
 
-        UserDomain userDomainElec = UserDomain.builder()
-            .email("testEmail123@sju.ac.kr")
-            .name("전통이")
-            .password(passwordEncoder.encode("qwer"))
-            .studentId(19111111L)
-            .majorsDomain(elecInfoMajor).build();
-        userDao.save(userDomainElec);
-
-        //Courses
-        CoursesDomain testCourse1 = CoursesDomain.builder()
-            .courseId(1234L)
-            .credit(3)
-            .name("testCourse1").build();
-        CoursesDomain testCourse2 = CoursesDomain.builder()
-            .courseId(2345L)
-            .credit(4)
-            .name("testCourse2").build();
-        CoursesDomain testCourse3 = CoursesDomain.builder()
-            .courseId(9000L)
-            .credit(5)
-            .name("testCourse3").build();
-        CoursesDomain testCourse4 = CoursesDomain.builder()
-            .courseId(9001L)
-            .credit(3)
-            .name("testCourse4").build();
-        CoursesDomain testCourse5 = CoursesDomain.builder()
-            .courseId(9002L)
-            .credit(3)
-            .name("testCourse5").build();
-        coursesDao.save(testCourse1);
-        coursesDao.save(testCourse2);
-        coursesDao.save(testCourse3);
-        coursesDao.save(testCourse4);
-        coursesDao.save(testCourse5);
-
-        //CompletedCourses
-        CompletedCoursesDomain coursesDomain1 = CompletedCoursesDomain.builder()
-            .year(19)
-            .semester("1학기")
-            .coursesDomain(testCourse1)
-            .userDomain(userDomain).build();
-        CompletedCoursesDomain coursesDomain2 = CompletedCoursesDomain.builder()
-            .year(19)
-            .semester("1학기")
-            .coursesDomain(testCourse2)
-            .userDomain(userDomain).build();
-        CompletedCoursesDomain coursesDomain3 = CompletedCoursesDomain.builder()
-            .year(19)
-            .semester("1학기")
-            .coursesDomain(testCourse3)
-            .userDomain(userDomain).build();
-        CompletedCoursesDomain coursesDomain4 = CompletedCoursesDomain.builder()
-            .year(19)
-            .semester("1학기")
-            .coursesDomain(testCourse4)
-            .userDomain(userDomain).build();
-
-        completedCoursesDao.save(coursesDomain1);
-        completedCoursesDao.save(coursesDomain2);
-        completedCoursesDao.save(coursesDomain3);
-        completedCoursesDao.save(coursesDomain4);
-
-        //gonghakCourses
-        GonghakCoursesDomain gonghakCourses1 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.BSM)
-            .majorsDomain(computerMajor)
-            .designCredit(0.0)
-            .coursesDomain(testCourse1)
-            .passCategory("인필")
-            .year(19).build();
-
-        GonghakCoursesDomain gonghakCourses2 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.BSM)
-            .majorsDomain(computerMajor)
-            .designCredit(0.0)
-            .coursesDomain(testCourse2)
-            .passCategory("인필")
-            .year(19).build();
-
-        GonghakCoursesDomain gonghakCourses3 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.전공)
-            .majorsDomain(computerMajor)
-            .designCredit(1.0)
-            .coursesDomain(testCourse3)
-            .passCategory("인선")
-            .year(19).build();
-
-        GonghakCoursesDomain gonghakCourses4 = GonghakCoursesDomain.builder()
-            .courseCategory(CourseCategoryConst.전공)
-            .majorsDomain(computerMajor)
-            .designCredit(1.0)
-            .coursesDomain(testCourse5)
-            .passCategory("인선")
-            .year(19).build();
-
-        gonghakCoursesDao.save(gonghakCourses1);
-        gonghakCoursesDao.save(gonghakCourses2);
-        gonghakCoursesDao.save(gonghakCourses3);
-        gonghakCoursesDao.save(gonghakCourses4);
     }
 
 

--- a/src/main/java/com/example/gimmegonghakauth/InitData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitData.java
@@ -49,37 +49,37 @@ public class InitData {
         majorsDao.save(computerMajor);
         majorsDao.save(elecInfoMajor);
 
-        //19학년도 computerMajor
+        //24학년도 computerMajor
         AbeekDomainBuilder abeek1 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.BSM)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(18);
         AbeekDomainBuilder abeek2 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(14);
         AbeekDomainBuilder abeek3 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.DESIGN)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(12);
+            .year(24)
+            .minCredit(10);
         AbeekDomainBuilder abeek4 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MAJOR)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(60);
+            .year(24)
+            .minCredit(45);
         AbeekDomainBuilder abeek5 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MINIMUM_CERTI)
             .majorsDomain(computerMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(92);
+            .year(24)
+            .minCredit(77);
 
         abeekDao.save(abeek1.build());
         abeekDao.save(abeek2.build());
@@ -87,37 +87,37 @@ public class InitData {
         abeekDao.save(abeek4.build());
         abeekDao.save(abeek5.build());
 
-        //19학년도 전정통
+        //24학년도 전정통
         AbeekDomainBuilder abeek21 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MSC)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(30);
+            .year(24)
+            .minCredit(27);
         AbeekDomainBuilder abeek22 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.PROFESSIONAL_NON_MAJOR)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(14);
         AbeekDomainBuilder abeek23 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.DESIGN)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
+            .year(24)
             .minCredit(9);
         AbeekDomainBuilder abeek24 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MAJOR)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(54);
+            .year(24)
+            .minCredit(45);
         AbeekDomainBuilder abeek25 = AbeekDomain.builder()
             .abeekType(AbeekTypeConst.MINIMUM_CERTI)
             .majorsDomain(elecInfoMajor)
             .note("this is a test note")
-            .year(19)
-            .minCredit(98);
+            .year(24)
+            .minCredit(86);
 
         abeekDao.save(abeek21.build());
         abeekDao.save(abeek22.build());

--- a/src/main/java/com/example/gimmegonghakauth/InitFileData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitFileData.java
@@ -29,7 +29,7 @@ public class InitFileData {
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void loadCoursesDataFromCSV() throws IOException {
-        String csvFilePath = "src/main/java/com/example/gimmegonghakauth/Course.csv";
+        String csvFilePath = "src/main/java/com/example/gimmegonghakauth/course.csv";
         inputCoursesCsv(csvFilePath);
 
         csvFilePath = "src/main/java/com/example/gimmegonghakauth/gonghak_course.csv";

--- a/src/main/java/com/example/gimmegonghakauth/InitFileData.java
+++ b/src/main/java/com/example/gimmegonghakauth/InitFileData.java
@@ -29,16 +29,10 @@ public class InitFileData {
     @EventListener(ApplicationReadyEvent.class)
     @Transactional
     public void loadCoursesDataFromCSV() throws IOException {
-        String csvFilePath = "src/main/java/com/example/gimmegonghakauth/19학년2학기_20학년1학기_컴공.csv";
-        inputCoursesCsv(csvFilePath);
-        csvFilePath = "src/main/java/com/example/gimmegonghakauth/19학년2학기_20학년1학기_전정통.csv";
-        inputCoursesCsv(csvFilePath);
-        csvFilePath = "src/main/java/com/example/gimmegonghakauth/19학년2학기_20학년1학기_대양.csv";
+        String csvFilePath = "src/main/java/com/example/gimmegonghakauth/Course.csv";
         inputCoursesCsv(csvFilePath);
 
-        csvFilePath = "src/main/java/com/example/gimmegonghakauth/computerMajorGonghakCourses2019Test.csv";
-        inputGonghakCoursesCsv(csvFilePath);
-        csvFilePath = "src/main/java/com/example/gimmegonghakauth/elecInfoMajorGonghakCourses2019Test.csv";
+        csvFilePath = "src/main/java/com/example/gimmegonghakauth/gonghak_course.csv";
         inputGonghakCoursesCsv(csvFilePath);
     }
 
@@ -80,7 +74,7 @@ public class InitFileData {
             while ((line = br.readLine()) != null) {
                 String[] data = line.split(cvsSplitBy);
                 try {
-                    Optional<GonghakCoursesDomain> course = mapToGonghakCoursesDomain(data);
+                    Optional<GonghakCoursesDomain> course = mapToGonghakCourses(data);
                     if (course.isPresent()) {
                         gonghakCoursesDao.save(course.get());
                     }
@@ -93,9 +87,10 @@ public class InitFileData {
         }
     }
 
+    // raw file 입력 용
     private Optional<GonghakCoursesDomain> mapToGonghakCoursesDomain(String[] data) {
 
-        CoursesDomain courseDomain = coursesDao.findByName(data[6].replaceAll("\\s+", ""));
+        CoursesDomain courseDomain = coursesDao.findByNameIgnoreSpaces(data[6].replaceAll("\\s+", ""));
         if (courseDomain == null) {
             return Optional.empty();
         }
@@ -124,6 +119,20 @@ public class InitFileData {
             .courseCategory(CourseCategoryConst.valueOf(courseCategory))
             .passCategory(data[5].substring(0, 2))
             .designCredit(Double.parseDouble(data[8]))
+            .build();
+
+        return Optional.of(gonghakCourse);
+    }
+
+    // 실제 DB csv file 입력용
+    private Optional<GonghakCoursesDomain> mapToGonghakCourses(String[] data) {
+        GonghakCoursesDomain gonghakCourse = GonghakCoursesDomain.builder()
+            .year(Integer.parseInt(data[1]))
+            .majorsDomain(majorsDao.findById(Long.parseLong(data[4])).get())
+            .coursesDomain(coursesDao.findByCourseId(Long.parseLong(data[2])))
+            .courseCategory(CourseCategoryConst.valueOf(data[5]))
+            .passCategory(data[6])
+            .designCredit(Double.parseDouble(data[0]))
             .build();
 
         return Optional.of(gonghakCourse);

--- a/src/main/java/com/example/gimmegonghakauth/dao/CoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CoursesDao.java
@@ -2,6 +2,8 @@ package com.example.gimmegonghakauth.dao;
 
 import com.example.gimmegonghakauth.domain.CoursesDomain;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -10,4 +12,8 @@ public interface CoursesDao extends JpaRepository<CoursesDomain, Long> {
     CoursesDomain findByCourseId(Long id);
 
     CoursesDomain findByName(String name);
+
+    // 띄워쓰기를 제외한 course.name 과 비교해서 반환하는 쿼리문
+    @Query(value ="select * from course where REPLACE(name, ' ', '') = :name", nativeQuery = true)
+    CoursesDomain findByNameIgnoreSpaces(@Param("name") String name);
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/CoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/CoursesDao.java
@@ -13,7 +13,7 @@ public interface CoursesDao extends JpaRepository<CoursesDomain, Long> {
 
     CoursesDomain findByName(String name);
 
-    // 띄워쓰기를 제외한 course.name 과 비교해서 반환하는 쿼리문
+    // 띄어쓰기를 제외한 course.name 과 비교해서 반환하는 쿼리문
     @Query(value ="select * from course where REPLACE(name, ' ', '') = :name", nativeQuery = true)
     CoursesDomain findByNameIgnoreSpaces(@Param("name") String name);
 }

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakCoursesDao.java
@@ -16,8 +16,8 @@ public interface GonghakCoursesDao extends JpaRepository<GonghakCoursesDomain,Lo
 
     @Query("select new com.example.gimmegonghakauth.dto.GonghakCoursesByMajorDto(GCD.coursesDomain.courseId, GCD.coursesDomain.name, GCD.year, GCD.courseCategory, GCD.passCategory, GCD.designCredit, GCD.coursesDomain.credit) from GonghakCoursesDomain GCD "
         + "join CompletedCoursesDomain CCD on GCD.coursesDomain = CCD.coursesDomain "
-        + "where CCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and CCD.year = GCD.year")
-    List<GonghakCoursesByMajorDto> findUserCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId);
+        + "where CCD.userDomain.studentId =:studentId and GCD.majorsDomain.id = :majorsId and GCD.year = :year")
+    List<GonghakCoursesByMajorDto> findUserCompletedCourses(@Param("studentId") Long studentId, @Param("majorsId") Long majorId, @Param("year") Long year);
 
     @Query("select new com.example.gimmegonghakauth.dto.IncompletedCoursesDto(GCD.coursesDomain.name, GCD.courseCategory, GCD.coursesDomain.credit, GCD.designCredit) from GonghakCoursesDomain GCD  "
         + "left join CompletedCoursesDomain CCD on CCD.coursesDomain = GCD.coursesDomain "

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -23,7 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GonghakDao implements GonghakRepository{
 
     private static final int DIVIDER = 1000000;
-    private static final int YEAR = 24;
+    private static final int LATEST_YEAR = 24;
     private final AbeekDao abeekDao;
     private final GonghakCoursesDao gonghakCoursesDao;
 
@@ -36,7 +36,7 @@ public class GonghakDao implements GonghakRepository{
     // 최신년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
     @Override
     public Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain){
-        return changeToGonghakStandardDto(majorsDomain, YEAR);
+        return changeToGonghakStandardDto(majorsDomain, LATEST_YEAR);
     }
 
     // gonghakCourse 중 이수한 과목을 불러온다.

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -43,7 +43,7 @@ public class GonghakDao implements GonghakRepository{
     @Override
     public List<GonghakCoursesByMajorDto> findUserCompletedCourses(
         Long studentId, MajorsDomain majorsDomain) {
-        return gonghakCoursesDao.findUserCompletedCourses(studentId,majorsDomain.getId());
+        return gonghakCoursesDao.findUserCompletedCourses(studentId,majorsDomain.getId(), studentId/DIVIDER);
     }
 
     // gonghakCourse 중 이수하지 않은 과목을 불러온다.

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakDao.java
@@ -23,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class GonghakDao implements GonghakRepository{
 
     private static final int DIVIDER = 1000000;
+    private static final int YEAR = 24;
     private final AbeekDao abeekDao;
     private final GonghakCoursesDao gonghakCoursesDao;
 
@@ -32,12 +33,10 @@ public class GonghakDao implements GonghakRepository{
         return abeekDomain;
     }
 
-    // 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+    // 최신년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
     @Override
-    public Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain) {
-        int year = (int) (studentId/DIVIDER);
-//        log.info("year = {}",year);
-        return changeToGonghakStandardDto(majorsDomain, year);
+    public Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain){
+        return changeToGonghakStandardDto(majorsDomain, YEAR);
     }
 
     // gonghakCourse 중 이수한 과목을 불러온다.
@@ -59,8 +58,6 @@ public class GonghakDao implements GonghakRepository{
         Map<AbeekTypeConst, Integer> standards = new ConcurrentHashMap<>();
         // year, major를 기준으로 abeek 데이터를 불러온다.
         List<AbeekDomain> allByYearAndMajorsDomain = abeekDao.findAllByYearAndMajorsDomain(year, majorsDomain);
-
-        log.info("allByYearAndMajorsDomain.isEmpty() = {}", allByYearAndMajorsDomain.isEmpty());
 
         // abeek을 기반으로 abeekType(영역별 구분),minCredit(영역별 인증학점) 저장한다.
         allByYearAndMajorsDomain.forEach(

--- a/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/GonghakRepository.java
@@ -15,7 +15,7 @@ public interface GonghakRepository {
 
     AbeekDomain save(AbeekDomain abeekDomain);
 
-    Optional<GonghakStandardDto> findStandard(Long studentId, MajorsDomain majorsDomain);
+    Optional<GonghakStandardDto> findStandard(MajorsDomain majorsDomain);
 
     List<GonghakCoursesByMajorDto> findUserCompletedCourses(Long studentId, MajorsDomain majorsDomain);
 

--- a/src/main/java/com/example/gimmegonghakauth/dao/MajorsDao.java
+++ b/src/main/java/com/example/gimmegonghakauth/dao/MajorsDao.java
@@ -1,6 +1,7 @@
 package com.example.gimmegonghakauth.dao;
 
 import com.example.gimmegonghakauth.domain.MajorsDomain;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Repository;
 public interface MajorsDao  extends JpaRepository<MajorsDomain, Long> {
     MajorsDomain findByMajor(String Major);
 
+    Optional<MajorsDomain> findById(Long id);
 }

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -25,7 +25,7 @@ public class GonghakCalculateService {
     @Transactional(readOnly = true)
     public Optional<GonghakResultDto> getResultRatio(UserDomain userDomain) {
 
-        // findLatestStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+        // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
             userDomain.getMajorsDomain());
 

--- a/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/GonghakCalculateService.java
@@ -25,9 +25,9 @@ public class GonghakCalculateService {
     @Transactional(readOnly = true)
     public Optional<GonghakResultDto> getResultRatio(UserDomain userDomain) {
 
-        // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
+        // findLatestStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
         Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+            userDomain.getMajorsDomain());
 
         // default user abeek 학점 상태 map
         Map<AbeekTypeConst, Double> userAbeekCredit = getUserAbeekCreditDefault(

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ComputerMajorGonghakRecommendService.java
@@ -29,8 +29,7 @@ public class ComputerMajorGonghakRecommendService implements GonghakRecommendSer
         GonghakRecommendCoursesDto gonghakRecommendCoursesDto = new GonghakRecommendCoursesDto();
 
         // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
         List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(

--- a/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
+++ b/src/main/java/com/example/gimmegonghakauth/service/recommend/ElecInfoMajorGonghakRecommendService.java
@@ -28,8 +28,7 @@ public class ElecInfoMajorGonghakRecommendService implements GonghakRecommendSer
         GonghakRecommendCoursesDto gonghakRecommendCoursesDto = new GonghakRecommendCoursesDto();
 
         // findStandard -> 학번 입학년도를 기준으로 해당 년도의 abeekType(영역별 구분),minCredit(영역별 인증학점) 불러온다.
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(
-            userDomain.getStudentId(), userDomain.getMajorsDomain());
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(userDomain.getMajorsDomain());
 
         // 수강하지 않은 과목 중 "전문 교양" 과목을 반환한다.
         List<IncompletedCoursesDto> professionalNonMajor = gonghakRepository.findUserIncompletedCourses(

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -58,6 +58,8 @@
               <option value="">-- 선택하세요 --</option>
               <option value="컴퓨터공학과">컴퓨터공학과</option>
               <option value="전자정보통신공학과">전자정보통신공학과</option>
+              <option value="소프트웨어학과">소프트웨어학과</option>
+              <option value="데이터사이언스학과">데이터사이언스학과</option>
             </select>
             <span th:if="${#fields.hasErrors('major')}" th:errors="*{major}" class="text-danger"
                   style="font-size: 1rem; margin-left: 13rem"></span>

--- a/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
+++ b/src/test/java/com/example/gimmegonghakauth/dao/GonghakRepositoryTest.java
@@ -78,7 +78,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("GonghakStandardDto 5가지 상태 모두 포함되어있는지 확인")
     void findStandardKeySetTest() {
-        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(COM_TEST_STUDENT_ID, COM_TEST_MAJORDOMAIN);
+        Optional<GonghakStandardDto> standard = gonghakRepository.findStandard(COM_TEST_MAJORDOMAIN);
         log.info("testStandard status ={}", standard.get().getStandards());
         Map<AbeekTypeConst, Integer> testStandard = standard.get().getStandards();
         assertThat(testStandard.keySet()).contains(AbeekTypeConst.BSM,AbeekTypeConst.PROFESSIONAL_NON_MAJOR,AbeekTypeConst.DESIGN,AbeekTypeConst.MAJOR,AbeekTypeConst.MINIMUM_CERTI);
@@ -140,9 +140,7 @@ class GonghakRepositoryTest {
     @Test
     @DisplayName("findStandard가 없을 때 - Wrong Major")
     void findStandardWrongMajorDomainTest(){
-        Optional<GonghakStandardDto> wrongStandard = gonghakRepository.findStandard(
-                COM_TEST_STUDENT_ID,
-                WRONG_TEST_MAJORDOMAIN);
+        Optional<GonghakStandardDto> wrongStandard = gonghakRepository.findStandard(WRONG_TEST_MAJORDOMAIN);
         assertThat(wrongStandard.get().getStandards().isEmpty()).isEqualTo(true);
     }
 }


### PR DESCRIPTION
## 🔧연결된 이슈
- https://github.com/Sejong-Java-Study/gonghak98/issues/57

## 🛠️작업 내용
- `findUserCompletedCourses`의 쿼리문을 **자신의 입학년도 기준의 과목을 불러오도록 리팩토링**

## 🤷‍♂️PR이 필요한 이유
- 이수하는 과목은 입학년도 기준을 따라야 하는데, 이전 리팩토링(https://github.com/Sejong-Java-Study/gonghak98/pull/60) 에서 이가 반영되지 않았습니다.
 

예를 들어 `데이터사이언스` 학과의 **19년도 교양**은 `ERP' , 'ELP'를 수강해야하는데, 해당 과목을 **교양 과목이 달라지는 22년도** 이후에 수강할 경우 **'교양'** 과목을 충족시키지 못하는것으로 계산되었습니다. (기존의 코드는 수강한 년도의 **GonghakCourse** 선택)


## ✔️PR 체크리스트
- [X] 필요한 테스트를 작성했는가?
- [X] 다른 코드를 깨뜨리지 않았는가?
- [X] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
