### PR TITLE
refactor: 결과표에 있는 영역 이름을 한글로 변경

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/constant/AbeekTypeConst.java
+++ b/src/main/java/com/example/gimmegonghakauth/constant/AbeekTypeConst.java
@@ -5,11 +5,18 @@ public enum AbeekTypeConst {
     PROFESSIONAL_NON_MAJOR("전문교양"),
     NON_MAJOR("교양"),
     MSC("MSC"),
-    MAJOR("전공학점"),
-    DESIGN("설계학점"),
-    MINIMUM_CERTI("최소인증학점"),
+    MAJOR("전공"),
+    DESIGN("설계"),
+    MINIMUM_CERTI("최소 이수학점"),
     BSM("BSM");
 
+    private final String typeMessage;
+
     AbeekTypeConst(String typeMessage) {
+        this.typeMessage = typeMessage;
+    }
+
+    public String getTypeMessage() {
+        return typeMessage;
     }
 }

--- a/src/main/resources/templates/gonghak/statusForm.html
+++ b/src/main/resources/templates/gonghak/statusForm.html
@@ -32,7 +32,7 @@
             </thead>
             <tbody>
             <tr th:each="resultRatio : ${userResultRatio}">
-              <td th:text="${resultRatio.getKey()}"></td>
+              <td th:text="${resultRatio.getKey().getTypeMessage()}"></td>
               <td th:text="${resultRatio.value.getUserPoint()}"></td>
               <td th:text="${resultRatio.value.getStandardPoint()}"></td>
               <td>
@@ -76,7 +76,7 @@
         <div class="py-5 text-center" th:each="recommendCourse : ${recommendCoursesByAbeekType}">
 
           <div th:if="${not #lists.isEmpty(recommendCourse.getValue())}">
-            <h3 th:text="${recommendCourse.getKey()}">type</h3>
+            <h2 th:text="${recommendCourse.getKey().getTypeMessage()}">type</h2>
             <div style="margin-bottom: 50px">
               <div class="table-container m-3"
                    style="max-height: 500px; overflow-y: auto; margin-top: 30px">


### PR DESCRIPTION
## 🔧연결된 이슈
- https://github.com/Sejong-Java-Study/gonghak98/issues/55

## 🛠️작업 내용
- 결과화면에 `AbeekType`의 **typeMessage**가 표시되도록 변경함
- 한글로 변경하는 과정에서 추천 영역이 글씨가 작아져 기존 `h3`에서 `h2`로 변경

## 🤷‍♂️PR이 필요한 이유
사용자에게 익숙한 영역 이름을 한글로 매칭시켜 인식하기 쉽게 변경했습니다.

AbeekType을 한글로 변경하다 보니, 기존의 `Result Ratio` , `RECOMMEND COURSES` 문구도 한글로 바꿔볼까 생각이 들었는데, 모두 한글이면 조금 밋밋한 느낌도 있는것 같아 아직은 수정하지 않았습니다. **이에 의견 부탁드립니다.**

![image](https://github.com/user-attachments/assets/fd53a371-8430-406b-b5af-a0f49d83391e)

![image](https://github.com/user-attachments/assets/93f453f5-1cda-43b6-a0bd-385cb207d6b9)


## ✔️PR 체크리스트
- [x] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [x] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
