### PR TITLE
feat: 선후수 과목에 대한 문구 추가

### DIFF
--- a/src/main/resources/static/js/verify.js
+++ b/src/main/resources/static/js/verify.js
@@ -2,7 +2,7 @@ function sendVerificationEmail() {
   var email = document.getElementById("email").value;
   var xhr = new XMLHttpRequest();
   if (!email) {
-    alert("세종대학교 이메일을 입력하세요.");
+    alert("세종대학교 이메일(@sju.ac.kr)을 입력하세요.");
     return;
   }
   xhr.open("POST", "/user/send-verification-email", true);

--- a/src/main/resources/templates/gonghak/statusForm.html
+++ b/src/main/resources/templates/gonghak/statusForm.html
@@ -7,7 +7,8 @@
       </div>
       <div class="title-bar-controls" style="margin-right: 10px">
         <button style="margin-right: 20px">
-          <img src="/static/images/questionmark.svg" style="height: 40px; width: 40px; padding:10px">
+          <img src="/static/images/questionmark.svg"
+               style="height: 40px; width: 40px; padding:10px">
         </button>
         <button>
           <img src="/static/images/x.svg" style="height: 40px; width: 40px; padding:10px">
@@ -46,7 +47,12 @@
             </tbody>
           </table>
         </div>
-
+        <div>
+          <h5>본 서비스는 선후수 관계를 고려하지 않습니다!</h5>
+          <h5>자세한 선후수 관계는<a href="https://abeek.sejong.ac.kr/index.do">
+            공식 사이트
+          </a>를 참조해주세요.</h5>
+        </div>
       </div>
 
       <hr/>


### PR DESCRIPTION
## 🔧연결된 이슈
- https://github.com/Sejong-Java-Study/gonghak98/issues/54

## 🛠️작업 내용
- 결과 화면에서 선후수 관계에 대한 안내 문구 추가
- 회원가입시 이메일에 대한 안내 문구 추가

## 🤷‍♂️PR이 필요한 이유

### 1. 결과 화면에서 선후수 관계에 대한 안내 문구 추가
기존 컨셉에 충실하기 위해서 문구만 삽입하고 다른 디자인적 요소는 넣지 않았습니다. 확실하게 공지하려는 느낌을 주려면 디자인을 변경해도 좋을것 같은데 **현 디자인에 대한 의견 남겨주세요.**
![image](https://github.com/user-attachments/assets/b516396e-8ec7-4ff0-b8c8-4d3d073eb031)

### 2. 회원가입시 이메일에 대한 안내 문구 추가
현재 **회원가입 시 이메일에 형식에 대한 안내**가 존재하지 않습니다. 사용자 편의를 높이기 위해 사용자가 이메일을 잘못 입력하였을 시 알림창에 이메일 형식(`@sju.ac.kr`) 을 추가하였습니다. 
더 편하게 하려면 이메일 입력창에 `@sju.ac.kr` 을 고정시켜놓고 앞부분만 입력받는 형식도 있으나, 이는 로직 수정이 필요할것 같아 안내문에만 추가하는 방식으로 수정하였습니다.
![image](https://github.com/user-attachments/assets/eefdec52-d91d-4f1f-8b6c-acfc3e61056e)


## ✔️PR 체크리스트
- [ ] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [ ] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
