### PR TITLE
feat: 일자별 가입자 수를 파악할 수 있도록 회원가입 시, 로그 출력

### DIFF
--- a/src/main/java/com/example/gimmegonghakauth/user/service/UserService.java
+++ b/src/main/java/com/example/gimmegonghakauth/user/service/UserService.java
@@ -1,16 +1,18 @@
 package com.example.gimmegonghakauth.user.service;
 
-import com.example.gimmegonghakauth.completed.infrastructure.CompletedCoursesDao;
-import com.example.gimmegonghakauth.user.infrastructure.UserRepository;
-import com.example.gimmegonghakauth.completed.domain.CompletedCoursesDomain;
 import com.example.gimmegonghakauth.common.domain.MajorsDomain;
+import com.example.gimmegonghakauth.completed.domain.CompletedCoursesDomain;
+import com.example.gimmegonghakauth.completed.infrastructure.CompletedCoursesDao;
 import com.example.gimmegonghakauth.user.domain.UserDomain;
+import com.example.gimmegonghakauth.user.infrastructure.UserRepository;
 import com.example.gimmegonghakauth.user.service.dto.ChangePasswordDto;
 import com.example.gimmegonghakauth.user.service.dto.UserJoinDto;
 import com.example.gimmegonghakauth.user.service.exception.UserNotFoundException;
 import com.example.gimmegonghakauth.user.service.port.UserEncoder;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,20 +21,24 @@ import org.springframework.validation.BindingResult;
 @Transactional
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
 
     private final UserRepository userRepository;
     private final CompletedCoursesDao completedCoursesDao;
     private final UserEncoder userEncoder;
 
-    public UserDomain create(String _studentId, String password, String email,
-        MajorsDomain majorsDomain, String name) {
+    public UserDomain create(String _studentId, String password, String email, MajorsDomain majorsDomain, String name) {
         Long studentId = Long.parseLong(_studentId);
         UserDomain user = UserDomain.builder()
-            .studentId(studentId).password(userEncoder.encode(password))
-            .email(email).majorsDomain(majorsDomain).name(name)
-            .build();
+                .studentId(studentId).password(userEncoder.encode(password))
+                .email(email).majorsDomain(majorsDomain).name(name)
+                .build();
         userRepository.save(user);
+
+        log.info("{} {}학번 {} {}님이 가입하셨습니다.",
+                LocalDate.now(), studentId / 1000000, majorsDomain.getMajor(), user.getName());
+
         return user;
     }
 
@@ -44,7 +50,7 @@ public class UserService {
 
     public UserDomain getByStudentId(Long studentId) {
         return userRepository.findByStudentId(studentId)
-            .orElseThrow(() -> new UserNotFoundException(studentId));
+                .orElseThrow(() -> new UserNotFoundException(studentId));
     }
 
     public boolean joinValidation(UserJoinDto userJoinDto, BindingResult bindingResult) {
@@ -82,7 +88,7 @@ public class UserService {
         Long studentId = Long.parseLong(_studentId);
 
         UserDomain user = userRepository.findByStudentId(studentId)
-            .orElseThrow(() -> new UsernameNotFoundException("학번이 존재하지 않습니다."));
+                .orElseThrow(() -> new UsernameNotFoundException("학번이 존재하지 않습니다."));
 
         if (userEncoder.matches(password, user.getPassword())) {
             List<CompletedCoursesDomain> coursesList = completedCoursesDao.findByUserDomain(user);
@@ -98,24 +104,24 @@ public class UserService {
     }
 
     public boolean changePasswordValidation(ChangePasswordDto changePasswordDto,
-        BindingResult bindingResult, UserDomain user) {
+                                            BindingResult bindingResult, UserDomain user) {
         String password = user.getPassword();
         String inputPassword = changePasswordDto.getCurrentPassword();
         if (!userEncoder.matches(inputPassword, password)) { //입력한 패스워드가 현재 패스워드와 일치하지 않을 경우
             bindingResult.rejectValue("currentPassword", "currentPasswordInCorrect",
-                "현재 패스워드가 일치하지 않습니다.");
+                    "현재 패스워드가 일치하지 않습니다.");
             return false;
         }
         if (userEncoder.matches(changePasswordDto.getNewPassword1(),
-            password)) { //입력한 새 패스워드가 현재 패스워드와 일치하는 경우
+                password)) { //입력한 새 패스워드가 현재 패스워드와 일치하는 경우
             bindingResult.rejectValue("newPassword1", "sameCurrentPassword",
-                "현재 패스워드와 다른 패스워드를 입력해주세요.");
+                    "현재 패스워드와 다른 패스워드를 입력해주세요.");
             return false;
         }
         if (!changePasswordDto.getNewPassword1()
-            .equals(changePasswordDto.getNewPassword2())) {//새 패스워드 2개의 입력이 일치하지 않는 경우
+                .equals(changePasswordDto.getNewPassword2())) {//새 패스워드 2개의 입력이 일치하지 않는 경우
             bindingResult.rejectValue("newPassword2", "newPasswordInCorrect",
-                "입력한 패스워드가 일치하지 않습니다.");
+                    "입력한 패스워드가 일치하지 않습니다.");
             return false;
         }
         return true;


### PR DESCRIPTION
## 🔧연결된 이슈
- closed

## 🛠️작업 내용
- 회원가입 성공 시, 로그 출력

## 🤷‍♂️PR이 필요한 이유
- 2차 서비스 오픈 후, 가입자 추이를 확인할 수 있도록 회원 가입 시 로그를 출력하도록 코드를 수정하였습니다.
- 가입일자, 학번, 학과, 이름이 로그로 출력됩니다.

<img width="523" alt="image" src="https://github.com/user-attachments/assets/5e542c09-6452-4159-ba49-d17e1e7101b8">

- 기존 `UserServiceTest`로 확인한 로그 포맷입니다.

## ✔️PR 체크리스트
- [ ] 필요한 테스트를 작성했는가?
- [x] 다른 코드를 깨뜨리지 않았는가?
- [ ] 연결된 이슈 외에 다른 이슈를 해결한 코드가 담겨있는가?
